### PR TITLE
Minor updates to version string handling and API key exposure

### DIFF
--- a/keepaAPI/Interface.py
+++ b/keepaAPI/Interface.py
@@ -907,6 +907,46 @@ class API(object):
         else:
             return response['categories']
 
+    def CategoryLookup(self, categoryId, domain='US', includeParents=0):
+        """
+        DESCRIPTION
+
+        EXAMPLE
+        # use 0 to return all root categories
+        categories = api.CategoryLookup(0)
+
+        # Print all root categories
+        for catId in categories:
+            print(catId, categories[catId]['name'])
+
+
+        INPUT
+        categoryId (integer)
+            ID for specific category or 0 to return a list of root categories.
+
+
+        OUTPUT
+        categories (list)
+            Output format is the same as SearchForCategories.
+
+        """
+        # Check if valid domain
+        if domain not in dcodes:
+            raise Exception('Invalid domain code')
+
+        payload = {'key': self.accesskey,
+                   'domain': dcodes.index(domain),
+                   'category': categoryId,
+                   'parents': includeParents}
+
+        r = requests.get('https://api.keepa.com/category/?', params=payload)
+        response = r.json()
+
+        if response['categories'] == {}:
+            logging.info('Category lookup results not yet available or no' +\
+                         'match found.')
+        else:
+            return response['categories']
 
     def GetAvailableTokens(self):
         """ Returns available tokens """

--- a/keepaAPI/Interface.py
+++ b/keepaAPI/Interface.py
@@ -505,7 +505,7 @@ class API(object):
         if log:
             logstr = '%(levelname)-7s: %(message)s'
             logging.basicConfig(format=logstr, level='DEBUG', filename='')
-            logging.info('Connecting to keepa using key {:s}'.format(accesskey))
+            logging.info('Connecting to keepa using key ending in {:s}'.format(accesskey[-6:]))
 
         # Store access key
         self.accesskey = accesskey
@@ -811,7 +811,7 @@ class API(object):
         information on how to get a category.
 
         Root category lists (e.g. "Home & Kitchen") or product group lists
-        contain up to 30,000 ASINs.
+        contain up to 100,000 ASINs.
 
         Sub-category lists (e.g. "Home Entertainment Furniture") contain up to
         3,000 ASINs. As we only have access to the product's primary sales rank

--- a/keepaAPI/__init__.py
+++ b/keepaAPI/__init__.py
@@ -1,5 +1,4 @@
-__version__ = '0.14.1'
-
+from keepaAPI._version import __version__
 from keepaAPI.Interface import *
 from keepaAPI.Plotting import *
 from keepaAPI.keepaTime import *

--- a/keepaAPI/_version.py
+++ b/keepaAPI/_version.py
@@ -1,5 +1,5 @@
 # major, minor, patch
-version_info = 0, 14, 2
+version_info = 0, 14, 2, 1
 
 
 # Nice string for the version

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ from setuptools import setup
 import os
 from io import open as io_open
 
+package_name = 'keepaAPI'
+
 # Get version from tqdm/_version.py
 __version__ = None
 version_file = os.path.join(os.path.dirname(__file__), package_name, '_version.py')
@@ -19,8 +21,8 @@ with io_open(version_file, mode='r') as fd:
     
 
 setup(
-    name='keepaAPI',
-    packages = ['keepaAPI'],
+    name=package_name,
+    packages = [package_name],
 
     # Version
     version=__version__,


### PR DESCRIPTION
Instead of logging the entire API key, just echo the last 6 characters. Remove redundant version string from __init__.py and update version.